### PR TITLE
Add 2:1 image mode for crisp pixels on low-dpi displays

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,7 +4,12 @@ use eframe::egui::TextureFilter;
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ImageMode {
+    /// One physical pixel in the input maps to one physical pixel in the output.
     Pixel,
+
+    /// One physical pixel in the input maps to two physical pixels in the output.
+    Pixel2,
+
     Fit,
 }
 

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -105,6 +105,9 @@ impl Snapshot {
             crate::settings::ImageMode::Pixel => {
                 image = image.fit_to_original_size(1.0 / state.egui_ctx.pixels_per_point());
             }
+            crate::settings::ImageMode::Pixel2 => {
+                image = image.fit_to_original_size(2.0 / state.egui_ctx.pixels_per_point());
+            }
             crate::settings::ImageMode::Fit => {}
         }
         image

--- a/src/viewer/viewer_options.rs
+++ b/src/viewer/viewer_options.rs
@@ -51,6 +51,7 @@ pub fn viewer_options(ui: &mut Ui, state: &ViewerAppStateRef<'_>) {
     ui.horizontal_wrapped(|ui| {
         ui.label("Size:");
         ui.selectable_value(&mut settings.mode, ImageMode::Pixel, "1:1");
+        ui.selectable_value(&mut settings.mode, ImageMode::Pixel2, "2:1");
         ui.selectable_value(&mut settings.mode, ImageMode::Fit, "Fit");
     });
 


### PR DESCRIPTION
`ImageMode::Pixel` (1:1) maps one physical input pixel to one physical output pixel, which becomes too small on low-dpi displays.

Adds a `Pixel2` (2:1) mode: one physical input pixel maps to two physical output pixels. Pixels stay crisp via the existing nearest-neighbor `texture_magnification`.

- `settings.rs` — new `ImageMode::Pixel2` variant
- `snapshot.rs` — `fit_to_original_size(2.0 / pixels_per_point())`
- `viewer_options.rs` — "2:1" selector between "1:1" and "Fit"

🤖 Generated with [Claude Code](https://claude.com/claude-code)