### PR TITLE
Pin cross images to fix arm musl CI builds

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,10 @@
+# Pin `cross` images to a known-good release so the C toolchain that
+# `ring` needs (e.g. `arm-linux-musleabihf-gcc`) is present.
+# Without this, the floating `:latest` images drift and drop the
+# cross-compiler, breaking the arm musl builds.
+
+[target.arm-unknown-linux-musleabihf]
+image = "ghcr.io/cross-rs/arm-unknown-linux-musleabihf:0.2.5"
+
+[target.armv7-unknown-linux-musleabihf]
+image = "ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:0.2.5"


### PR DESCRIPTION
The `arm-unknown-linux-musleabihf` and `armv7-unknown-linux-musleabihf` build jobs began failing with:

```
error occurred in cc-rs: failed to find tool "arm-linux-musleabihf-gcc": No such file or directory (os error 2)
error: failed to run custom build command for `ring v0.17.14`
```

`ring` (pulled in via `rustls` → `octocrab`/`ureq`) needs a C cross-compiler at build time. CI uses `actions-rs/cargo` with `use-cross: true`, which pulls the floating `cross` `:latest` images — these drifted and no longer ship the toolchain. No code or `Cargo.lock` change triggered this; it is pure image bitrot.

Fix: pin both arm musl `cross` images to the `0.2.5` release via `Cross.toml`, which ships the required `*-gcc`.

Followup (separate): `actions-rs/*` actions are deprecated/unmaintained since 2021 — worth replacing with a maintained cross action (e.g. `houseabsolute/actions-rust-cross`) to kill the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)